### PR TITLE
MTR-53-get-material-apico-MW-whiteList

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 .idea/
 docker-compose.yml
+.lingma

--- a/api/schema.yaml
+++ b/api/schema.yaml
@@ -207,6 +207,41 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /api/materials/get-material:
+    post:
+      summary: Get a material by UUID
+      operationId: GetMaterial
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetMaterialIn'
+      responses:
+        '200':
+          description: Material retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetMaterialOut'
+        '400':
+          description: Invalid input, missing required material UUID
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Material not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   schemas:
     SaveDraftMaterialIn:
@@ -341,6 +376,21 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Material'
+    GetMaterialIn:
+      type: object
+      required:
+        - material_uuid
+      properties:
+        material_uuid:
+          type: string
+          description: UUID of the material to retrieve
+    GetMaterialOut:
+      type: object
+      required:
+        - material
+      properties:
+        material:
+          $ref: '#/components/schemas/Material'
     Error:
       type: object
       required:

--- a/internal/generated/models.gen.go
+++ b/internal/generated/models.gen.go
@@ -30,6 +30,17 @@ type GetAllMaterialsOut struct {
 	MaterialList []Material `json:"material_list"`
 }
 
+// GetMaterialIn defines model for GetMaterialIn.
+type GetMaterialIn struct {
+	// MaterialUuid UUID of the material to retrieve
+	MaterialUuid string `json:"material_uuid"`
+}
+
+// GetMaterialOut defines model for GetMaterialOut.
+type GetMaterialOut struct {
+	Material Material `json:"material"`
+}
+
 // Material defines model for Material.
 type Material struct {
 	Content         string  `json:"content"`
@@ -96,6 +107,9 @@ type ToggleLikeJSONRequestBody = ToggleLikeIn
 
 // EditMaterialJSONRequestBody defines body for EditMaterial for application/json ContentType.
 type EditMaterialJSONRequestBody = EditMaterialIn
+
+// GetMaterialJSONRequestBody defines body for GetMaterial for application/json ContentType.
+type GetMaterialJSONRequestBody = GetMaterialIn
 
 // PublishMaterialJSONRequestBody defines body for PublishMaterial for application/json ContentType.
 type PublishMaterialJSONRequestBody = PublishMaterialIn

--- a/internal/generated/server.gen.go
+++ b/internal/generated/server.gen.go
@@ -22,6 +22,9 @@ type ServerInterface interface {
 	// Edit a material
 	// (POST /api/materials/edit-material)
 	EditMaterial(w http.ResponseWriter, r *http.Request)
+	// Get a material by UUID
+	// (POST /api/materials/get-material)
+	GetMaterial(w http.ResponseWriter, r *http.Request)
 	// Publish a material
 	// (POST /api/materials/publish-material)
 	PublishMaterial(w http.ResponseWriter, r *http.Request)
@@ -49,6 +52,12 @@ func (_ Unimplemented) ToggleLike(w http.ResponseWriter, r *http.Request) {
 // Edit a material
 // (POST /api/materials/edit-material)
 func (_ Unimplemented) EditMaterial(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get a material by UUID
+// (POST /api/materials/get-material)
+func (_ Unimplemented) GetMaterial(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -130,6 +139,21 @@ func (siw *ServerInterfaceWrapper) EditMaterial(w http.ResponseWriter, r *http.R
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.EditMaterial(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// GetMaterial operation middleware
+func (siw *ServerInterfaceWrapper) GetMaterial(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetMaterial(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -290,6 +314,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/api/materials/edit-material", wrapper.EditMaterial)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/api/materials/get-material", wrapper.GetMaterial)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/api/materials/publish-material", wrapper.PublishMaterial)

--- a/internal/infra/auth.go
+++ b/internal/infra/auth.go
@@ -36,11 +36,20 @@ func AuthInterceptorGRPC(
 
 func AuthInterceptorHTTP(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		method := r.Method
+
+		if (method == http.MethodGet && path == "/api/materials") ||
+			(method == http.MethodPost && path == "/api/materials/get-material") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		userID := r.Header.Get("X-User-Uuid")
 		userID = strings.TrimSpace(userID)
 
 		if userID == "" {
-			writeErrorResponse(w, "missing or empty X-User-ID header", http.StatusUnauthorized)
+			writeErrorResponse(w, "missing or empty X-User-Uuid header", http.StatusUnauthorized)
 			return
 		}
 

--- a/internal/rest/contract.go
+++ b/internal/rest/contract.go
@@ -20,6 +20,7 @@ type DBRepo interface {
 	WithTx(ctx context.Context, cb func(ctx context.Context) error) (err error)
 	EditMaterial(ctx context.Context, material *model.EditMaterial) (*model.Material, error)
 	GetAllMaterials(ctx context.Context, offset, limit int) (*model.MaterialList, error)
+	GetMaterial(ctx context.Context, materialUUID string) (*model.Material, error)
 }
 
 type KafkaProducer interface {

--- a/internal/rest/handler.go
+++ b/internal/rest/handler.go
@@ -390,6 +390,49 @@ func (h *Handler) GetAllMaterials(w http.ResponseWriter, r *http.Request, params
 	h.writeJSON(w, response, http.StatusOK)
 }
 
+func (h *Handler) GetMaterial(w http.ResponseWriter, r *http.Request) {
+	ctx := logger_lib.WithField(r.Context(), "func_name", "GetMaterial")
+
+	var req api.GetMaterialIn
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		logger_lib.Error(logger_lib.WithError(ctx, err), fmt.Sprintf("failed to decode request: %v", err))
+		h.writeError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.MaterialUuid == "" {
+		logger_lib.Error(ctx, "material uuid is required")
+		h.writeError(w, "material uuid is required", http.StatusBadRequest)
+		return
+	}
+
+	material, err := h.repository.GetMaterial(r.Context(), req.MaterialUuid)
+	if err != nil {
+		logger_lib.Error(logger_lib.WithError(ctx, err), fmt.Sprintf("failed to get material: %v", err))
+		if strings.Contains(err.Error(), "material doesn't exist") {
+			h.writeError(w, "material does not exist", http.StatusNotFound)
+		} else {
+			h.writeError(w, fmt.Sprintf("failed to get material: %v", err), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	response := api.GetMaterialOut{
+		Material: api.Material{
+			Uuid:            material.UUID,
+			OwnerUuid:       &material.OwnerUUID,
+			Title:           material.Title,
+			Content:         *material.Content,
+			Description:     material.Description,
+			CoverImageUrl:   material.CoverImageURL,
+			ReadTimeMinutes: material.ReadTimeMinutes,
+			Status:          material.Status,
+		},
+	}
+
+	h.writeJSON(w, response, http.StatusOK)
+}
+
 // ----------------------------- helpers -----------------------------
 
 func (h *Handler) writeJSON(w http.ResponseWriter, data interface{}, statusCode int) {

--- a/internal/rest/handler.go
+++ b/internal/rest/handler.go
@@ -395,7 +395,7 @@ func (h *Handler) GetMaterial(w http.ResponseWriter, r *http.Request) {
 
 	var req api.GetMaterialIn
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		logger_lib.Error(logger_lib.WithError(ctx, err), fmt.Sprintf("failed to decode request: %v", err))
+		logger_lib.Error(logger_lib.WithError(ctx, err), "failed to decode request")
 		h.writeError(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
@@ -408,7 +408,7 @@ func (h *Handler) GetMaterial(w http.ResponseWriter, r *http.Request) {
 
 	material, err := h.repository.GetMaterial(r.Context(), req.MaterialUuid)
 	if err != nil {
-		logger_lib.Error(logger_lib.WithError(ctx, err), fmt.Sprintf("failed to get material: %v", err))
+		logger_lib.Error(logger_lib.WithError(ctx, err), "failed to get material")
 		if strings.Contains(err.Error(), "material doesn't exist") {
 			h.writeError(w, "material does not exist", http.StatusNotFound)
 		} else {

--- a/internal/rest/mock_contract_test.go
+++ b/internal/rest/mock_contract_test.go
@@ -109,6 +109,21 @@ func (mr *MockDBRepoMockRecorder) GetLikesCount(ctx, materialUUID interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLikesCount", reflect.TypeOf((*MockDBRepo)(nil).GetLikesCount), ctx, materialUUID)
 }
 
+// GetMaterial mocks base method.
+func (m *MockDBRepo) GetMaterial(ctx context.Context, materialUUID string) (*model.Material, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMaterial", ctx, materialUUID)
+	ret0, _ := ret[0].(*model.Material)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMaterial indicates an expected call of GetMaterial.
+func (mr *MockDBRepoMockRecorder) GetMaterial(ctx, materialUUID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaterial", reflect.TypeOf((*MockDBRepo)(nil).GetMaterial), ctx, materialUUID)
+}
+
 // GetMaterialOwnerUUID mocks base method.
 func (m *MockDBRepo) GetMaterialOwnerUUID(ctx context.Context, materialUUID string) (string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Перенес RPC ручку getMaterial, добавил whitelist в MiddleWare авторизацию. Теперь не требуется заголовок X-User-Uuid для получения всех материалов и одного